### PR TITLE
TAR-71: replaced deprecated call to GG profile.

### DIFF
--- a/app/connector/FrontendAuthConnector.scala
+++ b/app/connector/FrontendAuthConnector.scala
@@ -18,6 +18,7 @@ package connector
 
 import config.WSHttp
 import model.CoAFEAuthority
+import play.api.libs.json.{Json, Reads}
 import uk.gov.hmrc.play.config.ServicesConfig
 import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
 import uk.gov.hmrc.play.http.HeaderCarrier
@@ -30,4 +31,14 @@ object FrontendAuthConnector extends FrontendAuthConnector with ServicesConfig {
 trait FrontendAuthConnector extends AuthConnector  {
 
   def currentCoAFEAuthority()(implicit hc: HeaderCarrier) = http.GET[CoAFEAuthority](s"$serviceUrl/auth/authority")
+
+  def getEnrolments(enrolmentsUri: String)(implicit hc: HeaderCarrier) = http.GET[Seq[GovernmentGatewayEnrolment]](s"$serviceUrl$enrolmentsUri")
+}
+
+case class EnrolmentIdentifier(key: String, value: String)
+case class GovernmentGatewayEnrolment(key: String, identifiers: Seq[EnrolmentIdentifier], state: String)
+
+object GovernmentGatewayEnrolment {
+  implicit val idReads: Reads[EnrolmentIdentifier] = Json.reads[EnrolmentIdentifier]
+  implicit val reads: Reads[GovernmentGatewayEnrolment] = Json.reads[GovernmentGatewayEnrolment]
 }

--- a/app/connector/UserDetailsConnector.scala
+++ b/app/connector/UserDetailsConnector.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connector
+
+import config.WSHttp
+import play.api.libs.json.{Json, Reads}
+import uk.gov.hmrc.play.config.ServicesConfig
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpGet, HttpPost}
+
+trait UserDetailsConnector {
+
+  val serviceUrl: String
+
+  def http: HttpGet with HttpPost
+
+  def getUserDetails(userDetailsUri: String)(implicit hc: HeaderCarrier) = http.GET[UserDetails](s"$serviceUrl$userDetailsUri")
+}
+
+object UserDetailsConnector extends UserDetailsConnector with ServicesConfig {
+  override lazy val serviceUrl = baseUrl("user-details")
+  override lazy val http = WSHttp
+}
+
+case class UserDetails(affinityGroup: String)
+
+object UserDetails {
+  implicit val reads: Reads[UserDetails] = Json.reads[UserDetails]
+}

--- a/app/controllers/RouterController.scala
+++ b/app/controllers/RouterController.scala
@@ -121,7 +121,9 @@ object TarRules extends RuleEngine {
 
     when(LoggedInViaGovernmentGateway and HasSelfAssessmentEnrolments and not(IsInAPartnership) and not(IsSelfEmployed)) thenGoTo PersonalTaxAccount withName "pta-home-page-for-user-with-no-partnership-and-no-self-employment",
 
-    when(HasIndividualAffinityGroup and not(HasAnyInactiveEnrolment)) thenGoTo PersonalTaxAccount withName "pta-home-page-individual",
+    when(not(HasAnyInactiveEnrolment) and not(AffinityGroupAvailable)) thenGoTo BusinessTaxAccount withName "bta-home-page-affinity-group-unavailable",
+
+    when(not(HasAnyInactiveEnrolment) and HasIndividualAffinityGroup) thenGoTo PersonalTaxAccount withName "pta-home-page-individual",
 
     when(AnyOtherRuleApplied) thenGoTo BusinessTaxAccount withName "bta-home-page-passed-through"
   )

--- a/app/model/AuditContext.scala
+++ b/app/model/AuditContext.scala
@@ -53,6 +53,7 @@ object RoutingReason {
   val HAS_ONLY_ONE_ENROLMENT = Reason("has-only-one-enrolment")
   val HAS_INDIVIDUAL_AFFINITY_GROUP = Reason("has-individual-affinity-group")
   val HAS_ANY_INACTIVE_ENROLMENT = Reason("has-any-inactive-enrolment")
+  val AFFINITY_GROUP_AVAILABLE = Reason("affinity-group-available")
 
   val allReasons = List(
     IS_A_VERIFY_USER,
@@ -70,7 +71,8 @@ object RoutingReason {
     HAS_STRONG_CREDENTIALS,
     HAS_ONLY_ONE_ENROLMENT,
     HAS_INDIVIDUAL_AFFINITY_GROUP,
-    HAS_ANY_INACTIVE_ENROLMENT
+    HAS_ANY_INACTIVE_ENROLMENT,
+    AFFINITY_GROUP_AVAILABLE
   )
 }
 

--- a/app/model/CoAFEAuthority.scala
+++ b/app/model/CoAFEAuthority.scala
@@ -20,7 +20,7 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
 import play.api.libs.json._
 
-case class CoAFEAuthority(twoFactorAuthOtpId: Option[String], enrolmentsUri: String = "", userDetailsLink: String = "")
+case class CoAFEAuthority(twoFactorAuthOtpId: Option[String], enrolmentsUri: String, userDetailsLink: String)
 
 object CoAFEAuthority {
   implicit val reads =

--- a/app/model/CoAFEAuthority.scala
+++ b/app/model/CoAFEAuthority.scala
@@ -16,10 +16,15 @@
 
 package model
 
+import play.api.libs.functional.syntax._
+import play.api.libs.json.Reads._
 import play.api.libs.json._
 
-case class CoAFEAuthority(twoFactorAuthOtpId: Option[String])
+case class CoAFEAuthority(twoFactorAuthOtpId: Option[String], enrolmentsUri: String = "", userDetailsLink: String = "")
 
 object CoAFEAuthority {
-  implicit val reads = Json.reads[CoAFEAuthority]
+  implicit val reads =
+    ((JsPath \ "twoFactorAuthOtpId").readNullable[String] and
+      (JsPath \ "enrolments").read[String] and
+      (JsPath \ "userDetailsLink").read[String]).apply(CoAFEAuthority.apply _)
 }

--- a/app/model/Conditions.scala
+++ b/app/model/Conditions.scala
@@ -36,6 +36,13 @@ object GGEnrolmentsAvailable extends Condition {
   override val auditType = Some(GG_ENROLMENTS_AVAILABLE)
 }
 
+object AffinityGroupAvailable extends Condition {
+  override def isTrue(authContext: AuthContext, ruleContext: RuleContext)(implicit request: Request[AnyContent], hc: HeaderCarrier) =
+    ruleContext.affinityGroup.map(_ => true).recover { case _ => false }
+
+  override val auditType = Some(AFFINITY_GROUP_AVAILABLE)
+}
+
 trait HasAnyBusinessEnrolment extends Condition {
   def businessEnrolments: Set[String]
 

--- a/app/model/Conditions.scala
+++ b/app/model/Conditions.scala
@@ -31,7 +31,7 @@ import scala.concurrent.Future
 
 object GGEnrolmentsAvailable extends Condition {
   override def isTrue(authContext: AuthContext, ruleContext: RuleContext)(implicit request: Request[AnyContent], hc: HeaderCarrier) =
-    ruleContext.activeEnrolments.map(_ => true).recover { case _ => false}
+    ruleContext.enrolments.map(_ => true).recover { case _ => false}
 
   override val auditType = Some(GG_ENROLMENTS_AVAILABLE)
 }

--- a/app/model/RuleContext.scala
+++ b/app/model/RuleContext.scala
@@ -24,7 +24,6 @@ import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext.fromLoggingDetai
 import scala.concurrent.Future
 
 case class RuleContext(authContext: AuthContext)(implicit hc: HeaderCarrier) {
-  val governmentGatewayConnector: GovernmentGatewayConnector = GovernmentGatewayConnector
   val selfAssessmentConnector: SelfAssessmentConnector = SelfAssessmentConnector
   val frontendAuthConnector: FrontendAuthConnector = FrontendAuthConnector
   val userDetailsConnector: UserDetailsConnector = UserDetailsConnector
@@ -32,9 +31,6 @@ case class RuleContext(authContext: AuthContext)(implicit hc: HeaderCarrier) {
   lazy val userDetails = currentCoAFEAuthority.flatMap { authority =>
     userDetailsConnector.getUserDetails(authority.userDetailsLink)
   }
-
-  // TODO: remove
-  lazy val futureProfile = governmentGatewayConnector.profile
 
   lazy val activeEnrolments = enrolments.map { enrolmentSeq =>
     enrolmentSeq.filter(_.state == EnrolmentState.ACTIVATED).map(_.key).toSet[String]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -120,6 +120,11 @@ microservice {
         domain = save4later
       }
     }
+
+    user-details {
+      host = "localhost",
+      port = 9978
+    }
   }
 }
 

--- a/it/configuration/StubApplicationConfiguration.scala
+++ b/it/configuration/StubApplicationConfiguration.scala
@@ -23,17 +23,15 @@ trait StubApplicationConfiguration {
 
   val databaseName = "tar-test"
 
+  val stubbedMicroServices = Seq("auth", "cachable.short-lived-cache", "government-gateway", "sa", "user-details")
+    .map(service => Map(
+      s"microservice.services.$service.host" -> stubHost,
+      s"microservice.services.$service.port" -> stubPort
+    )).reduce(_ ++ _)
+
   val config = Map[String, Any](
     "auditing.consumer.baseUri.host" -> stubHost,
     "auditing.consumer.baseUri.port" -> stubPort,
-    "microservice.services.auth.host" -> stubHost,
-    "microservice.services.auth.port" -> stubPort,
-    "microservice.services.cachable.short-lived-cache.host" -> stubHost,
-    "microservice.services.cachable.short-lived-cache.port" -> stubPort,
-    "microservice.services.government-gateway.host" -> stubHost,
-    "microservice.services.government-gateway.port" -> stubPort,
-    "microservice.services.sa.host" -> stubHost,
-    "microservice.services.sa.port" -> stubPort,
     "business-tax-account.host" -> s"http://$stubHost:$stubPort",
     "company-auth.host" -> s"http://$stubHost:$stubPort",
     "contact-frontend.host" -> s"http://$stubHost:$stubPort",
@@ -42,5 +40,5 @@ trait StubApplicationConfiguration {
     "tax-account-router.host" -> "",
     "throttling.enabled" -> false,
     "mongodb.uri" -> s"mongodb://localhost:27017/$databaseName"
-  )
+  ) ++ stubbedMicroServices
 }

--- a/it/router/RouterAuditFeature.scala
+++ b/it/router/RouterAuditFeature.scala
@@ -492,14 +492,14 @@ class RouterAuditFeature extends StubbedFeatureSpec with CommonStubs {
       verifyAuditEvent(auditEventStub, expectedReasons, expectedTransactionName, "pta-home-page-individual")
     }
 
-    scenario("when a user logged in through GG and has no sa and no business enrolment and affinity group n/a an audit event should be raised") {
+    scenario("when a user logged in through GG and has no sa and no business enrolment and affinity group not available an audit event should be raised") {
 
       Given("a user logged in through Government Gateway")
       val saUtr = "12345"
       val accounts = Accounts(sa = Some(SaAccount("", SaUtr(saUtr))))
       createStubs(TaxAccountUser(accounts = accounts, affinityGroup = AffinityGroupValue.INDIVIDUAL))
 
-      And("the user has self assessment enrolments and individual affinity group")
+      And("the user has no enrolments")
       stubNoEnrolments()
 
       And("affinity group is not available")

--- a/it/router/RouterAuditFeature.scala
+++ b/it/router/RouterAuditFeature.scala
@@ -58,7 +58,7 @@ class RouterAuditFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser())
 
       And("the user has business related enrolments")
-      stubProfileWithBusinessEnrolments()
+      stubBusinessEnrolments()
 
       val auditEventStub = stubAuditEvent()
 
@@ -90,7 +90,7 @@ class RouterAuditFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       And("the user has previous returns")
       stubSaReturnWithNoPreviousReturns(saUtr)
@@ -128,8 +128,11 @@ class RouterAuditFeature extends StubbedFeatureSpec with CommonStubs {
       val accounts = Accounts(sa = Some(SaAccount("", SaUtr(saUtr))))
       createStubs(TaxAccountUser(accounts = accounts))
 
-      And("the user has self assessment enrolments")
-      stubProfileWithNoEnrolments()
+      And("the user has no inactive enrolments")
+      stubNoEnrolments()
+
+      And("the user has organisation affinity group")
+      stubUserDetails(affinityGroup = AffinityGroupValue.ORGANISATION)
 
       val auditEventStub = stubAuditEvent()
 
@@ -163,7 +166,7 @@ class RouterAuditFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       And("the user is in a partnership")
       stubSaReturn(saUtr, previousReturns = true, supplementarySchedules = List("partnership"))
@@ -203,7 +206,7 @@ class RouterAuditFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       And("the user is self employed")
       stubSaReturn(saUtr, previousReturns = true, supplementarySchedules = List("self_employment"))
@@ -244,7 +247,7 @@ class RouterAuditFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       And("the user has previous returns and is not in a partnership and is not self employed and has no NINO")
       stubSaReturn(saUtr, previousReturns = true)
@@ -286,7 +289,7 @@ class RouterAuditFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       And("the user has previous returns and is not in a partnership and is not self employed and has NINO")
       stubSaReturn(saUtr, previousReturns = true)
@@ -324,7 +327,7 @@ class RouterAuditFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts, isRegisteredFor2SV = false))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       And("the user has previous returns")
       stubSaReturnWithNoPreviousReturns(saUtr)
@@ -361,7 +364,7 @@ class RouterAuditFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts, isRegisteredFor2SV = false))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       val auditEventStub = stubAuditEvent()
 
@@ -395,7 +398,7 @@ class RouterAuditFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts, isRegisteredFor2SV = false, credentialStrength = CredentialStrength.Strong))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       val auditEventStub = stubAuditEvent()
 
@@ -427,7 +430,7 @@ class RouterAuditFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts, isRegisteredFor2SV = false))
 
       And("the user has self assessment enrolments")
-      stubProfileWithMoreThanOneSAEnrolment()
+      stubMoreThanOneSAEnrolment()
 
       val auditEventStub = stubAuditEvent()
 
@@ -458,7 +461,10 @@ class RouterAuditFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts, affinityGroup = AffinityGroupValue.INDIVIDUAL))
 
       And("the user has self assessment enrolments and individual affinity group")
-      stubProfileWithNoEnrolments(affinityGroup = AffinityGroupValue.INDIVIDUAL)
+      stubNoEnrolments()
+
+      And("the user has individual affinity group")
+      stubUserDetails(affinityGroup = AffinityGroupValue.INDIVIDUAL)
 
       val auditEventStub = stubAuditEvent()
 

--- a/it/router/RouterAuditSaUnresponsiveFeature.scala
+++ b/it/router/RouterAuditSaUnresponsiveFeature.scala
@@ -38,7 +38,7 @@ class RouterAuditSaUnresponsiveFeature extends StubbedFeatureSpec with CommonStu
       createStubs(TaxAccountUser(accounts = accounts))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       And("the user has previous returns")
       stubSaReturnToProperlyRespondAfter2Seconds(saUtr)
@@ -78,7 +78,7 @@ class RouterAuditSaUnresponsiveFeature extends StubbedFeatureSpec with CommonStu
       createStubs(TaxAccountUser(accounts = accounts))
 
       And("the user has self assessment enrolments")
-      stubProfileToReturnAfter2Seconds()
+      stubEnrolmentsToReturnAfter2Seconds()
 
       val auditEventStub = stubAuditEvent()
 

--- a/it/router/RouterFeature.scala
+++ b/it/router/RouterFeature.scala
@@ -430,7 +430,7 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       verify(getRequestedFor(urlEqualTo("/enrolments-uri")))
 
       And("user's details should be fetched from User Details")
-      verify(getRequestedFor(urlEqualTo("/user-details-uri")))
+      verify(0, getRequestedFor(urlEqualTo("/user-details-uri")))
 
       And("Sa micro service should not be invoked")
       verify(0, getRequestedFor(urlMatching("/sa/individual/.[^\\/]+/return/last")))
@@ -452,6 +452,36 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
 
       Then("the user should be routed to PTA Home Page")
       on(PtaHomePage)
+
+      And("the authority object should be fetched once for AuthenticatedBy")
+      verify(getRequestedFor(urlEqualTo("/auth/authority")))
+
+      And("user's enrolments should be fetched from Auth")
+      verify(getRequestedFor(urlEqualTo("/enrolments-uri")))
+
+      And("user's details should be fetched from User Details")
+      verify(getRequestedFor(urlEqualTo("/user-details-uri")))
+
+      And("Sa micro service should not be invoked")
+      verify(0, getRequestedFor(urlMatching("/sa/individual/.[^\\/]+/return/last")))
+    }
+
+    scenario("a user logged in through GG and has no sa and no business enrolment and no inactive enrolments and affinity group not available should be redirected to BTA") {
+
+      Given("a user logged in through Government Gateway")
+      createStubs(TaxAccountUser(affinityGroup = AffinityGroupValue.INDIVIDUAL))
+
+      And("the user has no inactive enrolments and affinity group is not available")
+      stubNoEnrolments()
+      stubUserDetailsToReturn500()
+
+      createStubs(BtaHomeStubPage)
+
+      When("the user hits the router")
+      go(RouterRootPath)
+
+      Then("the user should be routed to PTA Home Page")
+      on(BtaHomePage)
 
       And("the authority object should be fetched once for AuthenticatedBy")
       verify(getRequestedFor(urlEqualTo("/auth/authority")))

--- a/it/router/RouterFeature.scala
+++ b/it/router/RouterFeature.scala
@@ -41,8 +41,11 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       And("the authority object should be fetched once for AuthenticatedBy")
       verify(getRequestedFor(urlEqualTo("/auth/authority")))
 
-      And("Government Gateway service should not be invoked")
-      verify(0, getRequestedFor(urlEqualTo("/profile")))
+      And("user's enrolments should not be fetched from Auth")
+      verify(0, getRequestedFor(urlEqualTo("/enrolments-uri")))
+
+      And("user's details should not be fetched from User Details")
+      verify(0, getRequestedFor(urlEqualTo("/user-details-uri")))
 
       And("Sa micro service should not be invoked")
       verify(0, getRequestedFor(urlMatching("/sa/individual/.[^\\/]+/return/last")))
@@ -54,7 +57,7 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser())
 
       And("the user has business related enrolments")
-      stubProfileWithBusinessEnrolments()
+      stubBusinessEnrolments()
 
       createStubs(BtaHomeStubPage)
 
@@ -67,8 +70,11 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       And("the authority object should be fetched once for AuthenticatedBy")
       verify(getRequestedFor(urlEqualTo("/auth/authority")))
 
-      And("the user profile should be fetched from the Government Gateway")
-      verify(getRequestedFor(urlEqualTo("/profile")))
+      And("user's enrolments should be fetched from Auth")
+      verify(getRequestedFor(urlEqualTo("/enrolments-uri")))
+
+      And("user's details should not be fetched from User Details")
+      verify(0, getRequestedFor(urlEqualTo("/user-details-uri")))
 
       And("Sa micro service should not be invoked")
       verify(0, getRequestedFor(urlMatching("/sa/individual/.[^\\/]+/return/last")))
@@ -82,7 +88,7 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       And("the user has previous returns")
       stubSaReturnWithNoPreviousReturns(saUtr)
@@ -98,8 +104,11 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       And("the authority object should be fetched once for AuthenticatedBy")
       verify(getRequestedFor(urlEqualTo("/auth/authority")))
 
-      And("the user profile should be fetched from the Government Gateway")
-      verify(getRequestedFor(urlEqualTo("/profile")))
+      And("user's enrolments should be fetched from Auth")
+      verify(getRequestedFor(urlEqualTo("/enrolments-uri")))
+
+      And("user's details should not be fetched from User Details")
+      verify(0, getRequestedFor(urlEqualTo("/user-details-uri")))
 
       And("sa returns should be fetched from Sa micro service")
       verify(getRequestedFor(urlEqualTo(s"/sa/individual/$saUtr/return/last")))
@@ -113,7 +122,7 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       And("the sa is returning 500")
       stubSaReturnToReturn500(saUtr)
@@ -129,14 +138,17 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       And("the authority object should be fetched once for AuthenticatedBy")
       verify(getRequestedFor(urlEqualTo("/auth/authority")))
 
-      And("the user profile should be fetched from the Government Gateway")
-      verify(getRequestedFor(urlEqualTo("/profile")))
+      And("user's enrolments should be fetched from Auth")
+      verify(getRequestedFor(urlEqualTo("/enrolments-uri")))
+
+      And("user's details should not be fetched from User Details")
+      verify(0, getRequestedFor(urlEqualTo("/user-details-uri")))
 
       And("sa returns should be fetched from Sa micro service")
       verify(getRequestedFor(urlEqualTo(s"/sa/individual/$saUtr/return/last")))
     }
 
-    scenario("a user logged in through GG and gg returning 500 should be redirected to BTA") {
+    scenario("a user logged in through GG and Auth returning 500 on GET enrolments should be redirected to BTA") {
 
       Given("a user logged in through Government Gateway")
       val saUtr = "12345"
@@ -144,7 +156,7 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts))
 
       And("gg is returning 500")
-      stubProfileToReturn500()
+      stubEnrolmentsToReturn500()
 
       createStubs(BtaHomeStubPage)
 
@@ -157,8 +169,11 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       And("the authority object should be fetched once for AuthenticatedBy")
       verify(getRequestedFor(urlEqualTo("/auth/authority")))
 
-      And("the user profile should be fetched from the Government Gateway")
-      verify(getRequestedFor(urlEqualTo("/profile")))
+      And("user's enrolments should be fetched from Auth")
+      verify(getRequestedFor(urlEqualTo("/enrolments-uri")))
+
+      And("user's details should not be fetched from User Details")
+      verify(0, getRequestedFor(urlEqualTo("/user-details-uri")))
 
       And("Sa micro service should not be invoked")
       verify(0, getRequestedFor(urlMatching("/sa/individual/.[^\\/]+/return/last")))
@@ -172,7 +187,7 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       And("the user is in a partnership")
       stubSaReturn(saUtr, previousReturns = true, supplementarySchedules = List("partnership"))
@@ -188,8 +203,11 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       And("the authority object should be fetched once for AuthenticatedBy")
       verify(getRequestedFor(urlEqualTo("/auth/authority")))
 
-      And("the user profile should be fetched from the Government Gateway")
-      verify(getRequestedFor(urlEqualTo("/profile")))
+      And("user's enrolments should be fetched from Auth")
+      verify(getRequestedFor(urlEqualTo("/enrolments-uri")))
+
+      And("user's details should not be fetched from User Details")
+      verify(0, getRequestedFor(urlEqualTo("/user-details-uri")))
 
       And("sa returns should be fetched from Sa micro service")
       verify(getRequestedFor(urlEqualTo(s"/sa/individual/$saUtr/return/last")))
@@ -203,7 +221,7 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       And("the user is self employed")
       stubSaReturn(saUtr, previousReturns = true, supplementarySchedules = List("self_employment"))
@@ -219,8 +237,11 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       And("the authority object should be fetched once for AuthenticatedBy")
       verify(getRequestedFor(urlEqualTo("/auth/authority")))
 
-      And("the user profile should be fetched from the Government Gateway")
-      verify(getRequestedFor(urlEqualTo("/profile")))
+      And("user's enrolments should be fetched from Auth")
+      verify(getRequestedFor(urlEqualTo("/enrolments-uri")))
+
+      And("user's details should not be fetched from User Details")
+      verify(0, getRequestedFor(urlEqualTo("/user-details-uri")))
 
       And("sa returns should be fetched from Sa micro service")
       verify(getRequestedFor(urlEqualTo(s"/sa/individual/$saUtr/return/last")))
@@ -234,7 +255,7 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       And("the user has previous returns and is not in a partnership and is not self employed and has no NINO")
       stubSaReturn(saUtr, previousReturns = true)
@@ -250,8 +271,11 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       And("the authority object should be fetched once for AuthenticatedBy")
       verify(getRequestedFor(urlEqualTo("/auth/authority")))
 
-      And("the user profile should be fetched from the Government Gateway")
-      verify(getRequestedFor(urlEqualTo("/profile")))
+      And("user's enrolments should be fetched from Auth")
+      verify(getRequestedFor(urlEqualTo("/enrolments-uri")))
+
+      And("user's details should not be fetched from User Details")
+      verify(0, getRequestedFor(urlEqualTo("/user-details-uri")))
 
       And("sa returns should be fetched from Sa micro service")
       verify(getRequestedFor(urlEqualTo(s"/sa/individual/$saUtr/return/last")))
@@ -265,7 +289,7 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       And("the user has previous returns and is not in a partnership and is not self employed and has NINO")
       stubSaReturn(saUtr, previousReturns = true)
@@ -278,8 +302,11 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       Then("the user should be routed to PTA Home Page")
       on(PtaHomePage)
 
-      And("the user profile should be fetched from the Government Gateway")
-      verify(getRequestedFor(urlEqualTo("/profile")))
+      And("user's enrolments should be fetched from Auth")
+      verify(getRequestedFor(urlEqualTo("/enrolments-uri")))
+
+      And("user's details should not be fetched from User Details")
+      verify(0, getRequestedFor(urlEqualTo("/user-details-uri")))
 
       And("sa returns should be fetched from Sa micro service")
       verify(getRequestedFor(urlEqualTo(s"/sa/individual/$saUtr/return/last")))
@@ -293,7 +320,7 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts, isRegisteredFor2SV = false))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       And("the user has previous returns")
       stubSaReturnWithNoPreviousReturns(saUtr)
@@ -309,8 +336,11 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       And("the authority object should be fetched once for AuthenticatedBy and once by 2SV")
       verify(2, getRequestedFor(urlEqualTo("/auth/authority")))
 
-      And("the user profile should be fetched from the Government Gateway")
-      verify(getRequestedFor(urlEqualTo("/profile")))
+      And("user's enrolments should be fetched from Auth")
+      verify(getRequestedFor(urlEqualTo("/enrolments-uri")))
+
+      And("user's details should not be fetched from User Details")
+      verify(0, getRequestedFor(urlEqualTo("/user-details-uri")))
 
       And("sa returns should be fetched from Sa micro service")
       verify(getRequestedFor(urlEqualTo(s"/sa/individual/$saUtr/return/last")))
@@ -323,7 +353,7 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts, isRegisteredFor2SV = false))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       createStubs(TwoSVPromptStubPage)
 
@@ -336,8 +366,11 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       And("the authority object should be fetched once for AuthenticatedBy and once by 2SV")
       verify(2, getRequestedFor(urlEqualTo("/auth/authority")))
 
-      And("the user profile should be fetched from the Government Gateway")
-      verify(getRequestedFor(urlEqualTo("/profile")))
+      And("user's enrolments should be fetched from Auth")
+      verify(getRequestedFor(urlEqualTo("/enrolments-uri")))
+
+      And("user's details should not be fetched from User Details")
+      verify(0, getRequestedFor(urlEqualTo("/user-details-uri")))
 
       And("Sa micro service should not be invoked")
       verify(0, getRequestedFor(urlMatching("/sa/individual/.[^\\/]+/return/last")))
@@ -350,7 +383,7 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts, isRegisteredFor2SV = false, credentialStrength = CredentialStrength.Strong))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       createStubs(BtaHomeStubPage)
 
@@ -363,8 +396,11 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       And("the authority object should be fetched once for AuthenticatedBy")
       verify(getRequestedFor(urlEqualTo("/auth/authority")))
 
-      And("the user profile should be fetched from the Government Gateway")
-      verify(getRequestedFor(urlEqualTo("/profile")))
+      And("user's enrolments should be fetched from Auth")
+      verify(getRequestedFor(urlEqualTo("/enrolments-uri")))
+
+      And("user's details should not be fetched from User Details")
+      verify(0, getRequestedFor(urlEqualTo("/user-details-uri")))
 
       And("Sa micro service should not be invoked")
       verify(0, getRequestedFor(urlMatching("/sa/individual/.[^\\/]+/return/last")))
@@ -376,7 +412,8 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(affinityGroup = AffinityGroupValue.INDIVIDUAL))
 
       And("the user has an inactive enrolment and individual affinity group")
-      stubProfileWithInactiveEnrolmentsAndIndividualAffinityGroup()
+      stubInactiveEnrolments()
+      stubUserDetails(affinityGroup = AffinityGroupValue.INDIVIDUAL)
 
       createStubs(BtaHomeStubPage)
 
@@ -389,8 +426,11 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       And("the authority object should be fetched once for AuthenticatedBy")
       verify(getRequestedFor(urlEqualTo("/auth/authority")))
 
-      And("the user profile should be fetched from the Government Gateway")
-      verify(getRequestedFor(urlEqualTo("/profile")))
+      And("user's enrolments should be fetched from Auth")
+      verify(getRequestedFor(urlEqualTo("/enrolments-uri")))
+
+      And("user's details should be fetched from User Details")
+      verify(getRequestedFor(urlEqualTo("/user-details-uri")))
 
       And("Sa micro service should not be invoked")
       verify(0, getRequestedFor(urlMatching("/sa/individual/.[^\\/]+/return/last")))
@@ -401,8 +441,9 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       Given("a user logged in through Government Gateway")
       createStubs(TaxAccountUser(affinityGroup = AffinityGroupValue.INDIVIDUAL))
 
-      And("the user has an no inactive enrolment and individual affinity group")
-      stubProfileWithNoEnrolments(affinityGroup = AffinityGroupValue.INDIVIDUAL)
+      And("the user has no inactive enrolments and individual affinity group")
+      stubNoEnrolments()
+      stubUserDetails(affinityGroup = AffinityGroupValue.INDIVIDUAL)
 
       createStubs(PtaHomeStubPage)
 
@@ -415,8 +456,11 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
       And("the authority object should be fetched once for AuthenticatedBy")
       verify(getRequestedFor(urlEqualTo("/auth/authority")))
 
-      And("the user profile should be fetched from the Government Gateway")
-      verify(getRequestedFor(urlEqualTo("/profile")))
+      And("user's enrolments should be fetched from Auth")
+      verify(getRequestedFor(urlEqualTo("/enrolments-uri")))
+
+      And("user's details should be fetched from User Details")
+      verify(getRequestedFor(urlEqualTo("/user-details-uri")))
 
       And("Sa micro service should not be invoked")
       verify(0, getRequestedFor(urlMatching("/sa/individual/.[^\\/]+/return/last")))

--- a/it/router/RouterSaUnresponsiveFeature.scala
+++ b/it/router/RouterSaUnresponsiveFeature.scala
@@ -32,7 +32,7 @@ class RouterSaUnresponsiveFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts))
 
       And("the user has self assessment enrolments")
-      stubProfileWithSelfAssessmentEnrolments()
+      stubSelfAssessmentEnrolments()
 
       And("the sa is unresponsive")
       stubSaReturnToProperlyRespondAfter2Seconds(saUtr)
@@ -48,8 +48,11 @@ class RouterSaUnresponsiveFeature extends StubbedFeatureSpec with CommonStubs {
       And("the authority object should be fetched once for AuthenticatedBy")
       verify(getRequestedFor(urlEqualTo("/auth/authority")))
 
-      And("the user profile should be fetched from the Government Gateway")
-      verify(getRequestedFor(urlEqualTo("/profile")))
+      And("user's enrolments should be fetched from Auth")
+      verify(getRequestedFor(urlEqualTo("/enrolments-uri")))
+
+      And("user's details should be fetched from User Details")
+      verify(0, getRequestedFor(urlEqualTo("/user-details-uri")))
 
       And("sa returns should be fetched from Sa micro service")
       verify(getRequestedFor(urlEqualTo(s"/sa/individual/$saUtr/return/last")))
@@ -63,7 +66,7 @@ class RouterSaUnresponsiveFeature extends StubbedFeatureSpec with CommonStubs {
       createStubs(TaxAccountUser(accounts = accounts))
 
       And("gg is unresponsive")
-      stubProfileToReturnAfter2Seconds()
+      stubEnrolmentsToReturnAfter2Seconds()
 
       createStubs(BtaHomeStubPage)
 
@@ -76,8 +79,11 @@ class RouterSaUnresponsiveFeature extends StubbedFeatureSpec with CommonStubs {
       And("the authority object should be fetched once for AuthenticatedBy")
       verify(getRequestedFor(urlEqualTo("/auth/authority")))
 
-      And("the user profile should be fetched from the Government Gateway")
-      verify(getRequestedFor(urlEqualTo("/profile")))
+      And("user's enrolments should be fetched from Auth")
+      verify(getRequestedFor(urlEqualTo("/enrolments-uri")))
+
+      And("user's details should be fetched from User Details")
+      verify(0, getRequestedFor(urlEqualTo("/user-details-uri")))
 
       And("Sa micro service should not be invoked")
       verify(0, getRequestedFor(urlMatching("/sa/individual/.[^\\/]+/return/last")))

--- a/it/support/Env.scala
+++ b/it/support/Env.scala
@@ -64,6 +64,6 @@ object Env {
     getInstance()
   }
 
-  val driver = phantomJsDriver
+  val driver = chromeWebDriver
 
 }

--- a/it/support/stubs/CommonStubs.scala
+++ b/it/support/stubs/CommonStubs.scala
@@ -27,6 +27,14 @@ trait CommonStubs {
       ))
   }
 
+  def stubUserDetailsToReturn500() = {
+    stubFor(get(urlMatching("/user-details-uri"))
+      .willReturn(
+        aResponse()
+          .withStatus(500)
+      ))
+  }
+
   def stubBusinessEnrolments() = {
     stubFor(get(urlEqualTo("/enrolments-uri"))
       .willReturn(

--- a/it/support/stubs/CommonStubs.scala
+++ b/it/support/stubs/CommonStubs.scala
@@ -1,88 +1,99 @@
 package support.stubs
 
 import com.github.tomakehurst.wiremock.client.WireMock._
-import connector.AffinityGroupValue
 import play.api.libs.json.Json
 
 trait CommonStubs {
 
-  def stubProfileWithBusinessEnrolments() = {
-    stubFor(get(urlMatching("/profile"))
-      .willReturn(aResponse()
-        .withStatus(200)
-        .withBody(
-          """
-            |{
-            |"affinityGroup":"Organisation",
-            |"enrolments":[
-            |                {"key": "enr1", "identifier": "5597800686", "state": "Activated"}
-            |             ]
-            |}
-            | """.stripMargin)))
+  def stubUserDetails(affinityGroup: String) = {
+    stubFor(get(urlMatching("/user-details-uri"))
+      .willReturn(
+        aResponse()
+          .withStatus(200)
+          .withBody(
+            s"""
+               |{
+               |    "name": "test",
+               |    "email": "test@test.com",
+               |    "affinityGroup": "$affinityGroup",
+               |    "description": "description",
+               |    "lastName": "test",
+               |    "dateOfBirth": "1980-06-31",
+               |    "postcode": "NW94HD",
+               |    "authProviderId": "12345-credId",
+               |    "authProviderType": "Verify"
+               |}
+      """.stripMargin)
+      ))
   }
 
-  def stubProfileWithInactiveEnrolmentsAndIndividualAffinityGroup() = {
-    stubFor(get(urlMatching("/profile"))
-      .willReturn(aResponse()
-        .withStatus(200)
-        .withBody(
-          """
-            |{
-            |"affinityGroup":"Individual",
-            |"enrolments":[
-            |                {"key": "enr1", "identifier": "5597800686", "state": "NotYetActivated"},
-            |                {"key": "enr10", "identifier": "5597800686", "state": "NotYetActivated"}
-            |             ]
-            |}
-            | """.stripMargin)))
+  def stubBusinessEnrolments() = {
+    stubFor(get(urlEqualTo("/enrolments-uri"))
+      .willReturn(
+        aResponse()
+          .withStatus(200)
+          .withBody(
+            """
+              |[
+              |   {"key": "enr1", "identifiers": [{"key": "k1", "value": "5597800686"}], "state": "Activated"}
+              |]
+            """.stripMargin)
+      ))
   }
 
-  def stubProfileWithSelfAssessmentEnrolments() = {
-    stubFor(get(urlMatching("/profile"))
-      .willReturn(aResponse()
-        .withStatus(200)
-        .withBody(
-          """
-            |{
-            |"affinityGroup":"Organisation",
-            |"enrolments":[
-            |                {"key": "enr3", "identifier": "5597800686", "state": "Activated"}
-            |             ]
-            |}
-            | """.stripMargin)))
+  def stubInactiveEnrolments() = {
+    stubFor(get(urlEqualTo("/enrolments-uri"))
+      .willReturn(
+        aResponse()
+          .withStatus(200)
+          .withBody(
+            """
+              |[
+              |   {"key": "enr1", "identifiers": [{"key": "k1", "value": "5597800686"}], "state": "NotYetActivated"},
+              |   {"key": "enr10", "identifiers": [{"key": "k2", "value": "5597800687"}], "state": "NotYetActivated"}
+              |]
+            """.stripMargin)
+      ))
   }
 
-  def stubProfileWithNoEnrolments(affinityGroup: String = AffinityGroupValue.ORGANISATION) = {
-    stubFor(get(urlMatching("/profile"))
-      .willReturn(aResponse()
-        .withStatus(200)
-        .withBody(
-          s"""
-            |{
-            |"affinityGroup":"$affinityGroup",
-            |"enrolments":[]
-            |}
-            | """.stripMargin)))
+  def stubSelfAssessmentEnrolments() = {
+    stubFor(get(urlEqualTo("/enrolments-uri"))
+      .willReturn(
+        aResponse()
+          .withStatus(200)
+          .withBody(
+            """
+              |[
+              |   {"key": "enr3", "identifiers": [{"key": "k1", "value": "5597800686"}], "state": "Activated"}
+              |]
+            """.stripMargin)
+      ))
   }
 
-  def stubProfileToReturnAfter2Seconds() = {
-    stubFor(get(urlMatching("/profile"))
+  def stubNoEnrolments() = {
+    stubFor(get(urlMatching("/enrolments-uri"))
       .willReturn(aResponse()
         .withStatus(200)
-        .withFixedDelay(2000) // For the tests to correctly fail this value must be greater than the ws.timeout.request used by the test.
-        .withBody(
-          """
-            |{
-            |"affinityGroup":"Organisation",
-            |"enrolments":[
-            |                {"key": "enr3", "identifier": "5597800686", "state": "Activated"}
-            |             ]
-            |}
-            | """.stripMargin)))
+        .withBody("[]")))
   }
 
-  def stubProfileToReturn500() = {
-    stubFor(get(urlMatching("/profile"))
+  def stubEnrolmentsToReturnAfter2Seconds() = {
+    stubFor(get(urlEqualTo("/enrolments-uri"))
+      .willReturn(
+        aResponse()
+          .withStatus(200)
+          .withFixedDelay(2000) // For the tests to correctly fail this value must be greater than the ws.timeout.request used by the test.
+          .withBody(
+            """
+              |[
+              |   {"key": "enr3", "identifiers": [{"key": "k1", "value": "5597800686"}], "state": "Activated"}
+              |]
+            """.stripMargin)
+      ))
+  }
+
+  def stubEnrolmentsToReturn500() = {
+    stubFor(get(urlMatching("/enrolments-uri"))
       .willReturn(aResponse()
         .withStatus(500)))
   }
@@ -135,19 +146,18 @@ trait CommonStubs {
 
   def stubAuditEvent() = postRequestedFor(urlMatching("/write/audit.*"))
 
-  def stubProfileWithMoreThanOneSAEnrolment() = {
-    stubFor(get(urlMatching("/profile"))
-      .willReturn(aResponse()
-        .withStatus(200)
-        .withBody(
-          """
-            |{
-            |"affinityGroup":"Organisation",
-            |"enrolments":[
-            |                {"key": "enr1", "identifier": "5597800686", "state": "Activated"},
-            |                {"key": "enr4", "identifier": "5597800686", "state": "Activated"}
-            |             ]
-            |}
-            | """.stripMargin)))
+  def stubMoreThanOneSAEnrolment() = {
+    stubFor(get(urlEqualTo("/enrolments-uri"))
+      .willReturn(
+        aResponse()
+          .withStatus(200)
+          .withBody(
+            """
+              |[
+              |   {"key": "enr1", "identifiers": [{"key": "k1", "value": "5597800686"}], "state": "Activated"},
+              |   {"key": "enr4", "identifiers": [{"key": "k2", "value": "5597800687"}], "state": "Activated"}
+              |]
+            """.stripMargin)
+      ))
   }
 }

--- a/it/support/stubs/StubbedFeatureSpec.scala
+++ b/it/support/stubs/StubbedFeatureSpec.scala
@@ -25,9 +25,6 @@ import org.scalatestplus.play.OneServerPerSuite
 import play.api.test.FakeApplication
 import support.Env
 import support.sugar._
-import uk.gov.hmrc.mongo.MongoConnector
-
-import scala.concurrent.ExecutionContext.Implicits.global
 
 trait StubbedFeatureSpec
   extends FeatureSpec
@@ -49,8 +46,6 @@ trait StubbedFeatureSpec
 
   val wireMockServer: WireMockServer = new WireMockServer(wireMockConfig().port(stubPort))
 
-  val databaseConnection = new MongoConnector(s"mongodb://127.0.0.1:27017/$databaseName").db
-
   override def beforeAll() = {
     wireMockServer.start()
     WireMock.configureFor(stubHost, stubPort)
@@ -58,7 +53,6 @@ trait StubbedFeatureSpec
 
   override def afterAll() = {
     wireMockServer.stop()
-    databaseConnection().drop()
   }
 
   sys addShutdownHook {
@@ -68,7 +62,6 @@ trait StubbedFeatureSpec
   override def beforeEach() = {
     Env.driver.manage().deleteAllCookies()
     WireMock.reset()
-    databaseConnection().drop()
   }
 
 }

--- a/it/support/stubs/TaxAccountUser.scala
+++ b/it/support/stubs/TaxAccountUser.scala
@@ -19,32 +19,21 @@ package support.stubs
 import connector.AffinityGroupValue
 import uk.gov.hmrc.play.frontend.auth.connectors.domain.{Accounts, CredentialStrength}
 
-class TaxAccountUser(loggedIn: Boolean,
-                     tokenPresent: Boolean,
-                     isRegisteredFor2SV: Boolean,
-                     accounts: Accounts,
-                     credentialStrength: CredentialStrength,
-                     affinityGroup: String)
+case class TaxAccountUser(loggedIn: Boolean = true,
+                          tokenPresent: Boolean = true,
+                          isRegisteredFor2SV: Boolean = true,
+                          accounts: Accounts = Accounts(),
+                          credentialStrength: CredentialStrength = CredentialStrength.None,
+                          affinityGroup: String = AffinityGroupValue.ORGANISATION,
+                          oid: String = "1234567890")
   extends Stub {
 
   def create() = {
     if (loggedIn) {
-      LoggedInSessionUser(tokenPresent, isRegisteredFor2SV, accounts, credentialStrength, affinityGroup).create()
+      LoggedInSessionUser(tokenPresent, isRegisteredFor2SV, accounts, credentialStrength, affinityGroup, oid).create()
 
     } else {
       LoggedOutSessionUser.create
     }
-  }
-}
-
-object TaxAccountUser {
-
-  def apply(loggedIn: Boolean = true,
-            tokenPresent: Boolean = true,
-            isRegisteredFor2SV: Boolean = true,
-            accounts: Accounts = Accounts(),
-            credentialStrength: CredentialStrength = CredentialStrength.None,
-            affinityGroup: String = AffinityGroupValue.ORGANISATION) = {
-    new TaxAccountUser(loggedIn, tokenPresent, isRegisteredFor2SV, accounts, credentialStrength, affinityGroup)
   }
 }

--- a/it/support/stubs/authStubs.scala
+++ b/it/support/stubs/authStubs.scala
@@ -53,7 +53,8 @@ class LoggedInSessionUser(tokenPresent: Boolean,
                           isRegisteredFor2SV: Boolean,
                           accounts: Accounts,
                           credentialStrength: CredentialStrength,
-                          affinityGroup: String) extends Stub with SessionCookieBaker {
+                          affinityGroup: String,
+                          oid: String) extends Stub with SessionCookieBaker {
 
   private val twoFactorAuthOtpId = if (isRegisteredFor2SV) """"twoFactorAuthOtpId": "1234",""" else ""
   private val credentialStrengthField = s""""credentialStrength": "${credentialStrength.name.toLowerCase}","""
@@ -88,7 +89,7 @@ class LoggedInSessionUser(tokenPresent: Boolean,
           .withBody(
             s"""
                |{
-               |    "authId": "/auth/oid/1234567890",
+               |    s"authId": "/auth/oid/$oid",
                |    "credId": "cred-id-12345",
                |    "name": "JOHN THE SAINSBURY",
                |    $affinityGroupField
@@ -110,7 +111,9 @@ class LoggedInSessionUser(tokenPresent: Boolean,
                |    "accounts":${Json.toJson(accounts)},
                |    "levelOfAssurance": "2",
                |    $credentialStrengthField
-               |    "confidenceLevel": 500
+               |    "confidenceLevel": 500,
+               |    "enrolments": "/enrolments-uri",
+               |    "userDetailsLink": "/user-details-uri"
                |}
                |"""
               .stripMargin
@@ -123,6 +126,7 @@ object LoggedInSessionUser {
             isRegisteredFor2SV: Boolean,
             accounts: Accounts,
             credentialStrength: CredentialStrength,
-            affinityGroup: String) =
-    new LoggedInSessionUser(tokenPresent, isRegisteredFor2SV, accounts, credentialStrength, affinityGroup)
+            affinityGroup: String,
+            oid: String) =
+    new LoggedInSessionUser(tokenPresent, isRegisteredFor2SV, accounts, credentialStrength, affinityGroup, oid)
 }

--- a/test/connector/UserDetailsConnectorSpec.scala
+++ b/test/connector/UserDetailsConnectorSpec.scala
@@ -1,10 +1,63 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package connector
 
+import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import uk.gov.hmrc.play.http.ws.WSHttp
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpGet, HttpPost, HttpReads}
 import uk.gov.hmrc.play.test.UnitSpec
 
-class UserDetailsConnectorSpec extends UnitSpec {
+import scala.concurrent.Future
+
+class UserDetailsConnectorSpec extends UnitSpec with MockitoSugar {
+
+  sealed trait Setup {
+
+    val mockHttp = mock[WSHttp]
+
+    val someServiceUrl = "/some-service-url"
+
+    val hc = HeaderCarrier()
+
+    val connectorUnderTest = new UserDetailsConnector {
+
+      override def http: HttpGet with HttpPost = mockHttp
+
+      override val serviceUrl = someServiceUrl
+
+    }
+  }
 
   "getUserDetails" should {
-    "" in {}
+    "get user details from user-details microservice" in new Setup {
+
+      val userDetailsUri = "userDetailsUri"
+
+      val expected = UserDetails(affinityGroup = "Individual")
+      when(mockHttp.GET(eqTo(s"$someServiceUrl$userDetailsUri"))(any[HttpReads[UserDetails]], eqTo(hc))).thenReturn(Future.successful(expected))
+
+      val result = await(connectorUnderTest.getUserDetails(userDetailsUri)(hc))
+
+      result shouldBe expected
+
+      verify(mockHttp).GET[UserDetails](eqTo(s"$someServiceUrl$userDetailsUri"))(any[HttpReads[UserDetails]], eqTo(hc))
+      verifyNoMoreInteractions(mockHttp)
+    }
   }
 }

--- a/test/connector/UserDetailsConnectorSpec.scala
+++ b/test/connector/UserDetailsConnectorSpec.scala
@@ -1,0 +1,10 @@
+package connector
+
+import uk.gov.hmrc.play.test.UnitSpec
+
+class UserDetailsConnectorSpec extends UnitSpec {
+
+  "getUserDetails" should {
+    "" in {}
+  }
+}

--- a/test/engine/ConditionsSpec.scala
+++ b/test/engine/ConditionsSpec.scala
@@ -356,7 +356,7 @@ class ConditionsSpec extends UnitSpec with MockitoSugar with WithFakeApplication
 
         implicit val hc = HeaderCarrier.fromHeadersAndSession(fakeRequest.headers)
         val ruleContext = mock[RuleContext]
-        when(ruleContext.currentCoAFEAuthority).thenReturn(Future(CoAFEAuthority(twoFactorAuthOtpId)))
+        when(ruleContext.currentCoAFEAuthority).thenReturn(Future(CoAFEAuthority(twoFactorAuthOtpId, "", "")))
 
         val result = await(HasRegisteredFor2SV.isTrue(authContext, ruleContext))
 

--- a/test/engine/ConditionsSpec.scala
+++ b/test/engine/ConditionsSpec.scala
@@ -16,7 +16,7 @@
 
 package engine
 
-import connector.{AffinityGroupValue, SaReturn}
+import connector.{GovernmentGatewayEnrolment, AffinityGroupValue, SaReturn}
 import model.RoutingReason._
 import model._
 import org.mockito.Mockito._
@@ -426,15 +426,15 @@ class ConditionsSpec extends UnitSpec with MockitoSugar with WithFakeApplication
         val ruleContext = mock[RuleContext]
 
         val expectedResult = ggEnrolmentsAvailable match {
-          case true => Future.successful(Set.empty[String])
+          case true => Future.successful(Seq.empty[GovernmentGatewayEnrolment])
           case false => Future.failed(new RuntimeException())
         }
-        when(ruleContext.activeEnrolments).thenReturn(expectedResult)
+        when(ruleContext.enrolments).thenReturn(expectedResult)
 
         val result = await(GGEnrolmentsAvailable.isTrue(authContext, ruleContext))
 
         result shouldBe ggEnrolmentsAvailable
-        verify(ruleContext).activeEnrolments
+        verify(ruleContext).enrolments
         verifyNoMoreInteractions(ruleContext, authContext)
       }
     }

--- a/test/model/AuditContextSpec.scala
+++ b/test/model/AuditContextSpec.scala
@@ -69,7 +69,8 @@ class AuditContextSpec extends UnitSpec with WithFakeApplication with MockitoSug
         "has-strong-credentials" -> "-",
         "has-only-one-enrolment" -> "-",
         "has-individual-affinity-group" -> "-",
-        "has-any-inactive-enrolment" -> "-"
+        "has-any-inactive-enrolment" -> "-",
+        "affinity-group-available" -> "-"
       )
     }
   }
@@ -95,6 +96,7 @@ class AuditContextSpec extends UnitSpec with WithFakeApplication with MockitoSug
       auditContext.setRoutingReason(HAS_ONLY_ONE_ENROLMENT, result = true)
       auditContext.setRoutingReason(HAS_INDIVIDUAL_AFFINITY_GROUP, result = true)
       auditContext.setRoutingReason(HAS_ANY_INACTIVE_ENROLMENT, result = true)
+      auditContext.setRoutingReason(AFFINITY_GROUP_AVAILABLE, result = true)
 
       auditContext.ruleApplied = "rule-name"
 
@@ -122,7 +124,8 @@ class AuditContextSpec extends UnitSpec with WithFakeApplication with MockitoSug
         "has-strong-credentials" -> "true",
         "has-only-one-enrolment" -> "true",
         "has-individual-affinity-group" -> "true",
-        "has-any-inactive-enrolment" -> "true"
+        "has-any-inactive-enrolment" -> "true",
+        "affinity-group-available" -> "true"
       )
 
       val throttlingMap: Map[String, String] = Map()

--- a/test/services/TwoStepVerificationServiceSpec.scala
+++ b/test/services/TwoStepVerificationServiceSpec.scala
@@ -164,7 +164,7 @@ class TwoStepVerificationServiceSpec extends UnitSpec with MockitoSugar with Wit
 
       result shouldBe None
       verify(ruleContext, times(2)).activeEnrolments
-      verify(ruleContext, times(1)).enrolments
+      verify(ruleContext).enrolments
       verifyNoMoreInteractions(ruleContext)
     }
 
@@ -211,8 +211,8 @@ class TwoStepVerificationServiceSpec extends UnitSpec with MockitoSugar with Wit
       val result = await(twoStepVerification.getDestinationVia2SV(BusinessTaxAccount, ruleContext, auditContext))
 
       result shouldBe None
-      verify(ruleContext, times(1)).enrolments
-      verify(ruleContext, times(1)).activeEnrolments
+      verify(ruleContext).enrolments
+      verify(ruleContext).activeEnrolments
       verifyNoMoreInteractions(ruleContext)
     }
 
@@ -240,7 +240,7 @@ class TwoStepVerificationServiceSpec extends UnitSpec with MockitoSugar with Wit
       result shouldBe Some(Locations.twoStepVerification(Map("continue" -> continueUrl, "failure" -> continueUrl, "origin" -> "business-tax-account")))
       verify(ruleContext).currentCoAFEAuthority
       verify(ruleContext, times(2)).activeEnrolments
-      verify(ruleContext, times(1)).enrolments
+      verify(ruleContext).enrolments
       verifyNoMoreInteractions(ruleContext)
     }
   }

--- a/test/services/TwoStepVerificationServiceSpec.scala
+++ b/test/services/TwoStepVerificationServiceSpec.scala
@@ -157,7 +157,7 @@ class TwoStepVerificationServiceSpec extends UnitSpec with MockitoSugar with Wit
         override def twoStepVerificationEnabled = true
       }
 
-      when(ruleContext.currentCoAFEAuthority).thenReturn(Future.successful(CoAFEAuthority(Some("1234"))))
+      when(ruleContext.currentCoAFEAuthority).thenReturn(Future.successful(CoAFEAuthority(Some("1234"), "", "")))
       when(ruleContext.activeEnrolments).thenReturn(Future.successful(Set("IR-SA")))
       when(ruleContext.enrolments).thenReturn(Future.successful(Seq.empty[GovernmentGatewayEnrolment]))
       val result = await(twoStepVerification.getDestinationVia2SV(BusinessTaxAccount, ruleContext, auditContext))
@@ -181,7 +181,7 @@ class TwoStepVerificationServiceSpec extends UnitSpec with MockitoSugar with Wit
         override def twoStepVerificationEnabled = true
       }
 
-      when(ruleContext.currentCoAFEAuthority).thenReturn(Future.successful(CoAFEAuthority(Some("1234"))))
+      when(ruleContext.currentCoAFEAuthority).thenReturn(Future.successful(CoAFEAuthority(Some("1234"), "", "")))
       when(ruleContext.enrolments).thenReturn(Future.failed(new InternalServerException("GG returns 500")))
 
       val result = await(twoStepVerification.getDestinationVia2SV(BusinessTaxAccount, ruleContext, auditContext))
@@ -204,7 +204,7 @@ class TwoStepVerificationServiceSpec extends UnitSpec with MockitoSugar with Wit
         override def twoStepVerificationEnabled = true
       }
 
-      when(ruleContext.currentCoAFEAuthority).thenReturn(Future.successful(CoAFEAuthority(Some("1234"))))
+      when(ruleContext.currentCoAFEAuthority).thenReturn(Future.successful(CoAFEAuthority(Some("1234"), "", "")))
       when(ruleContext.enrolments).thenReturn(Future.successful(Seq.empty[GovernmentGatewayEnrolment]))
       when(ruleContext.activeEnrolments).thenReturn(Future.successful(Set("IR-SA", "some-other-enrolment")))
 
@@ -231,7 +231,7 @@ class TwoStepVerificationServiceSpec extends UnitSpec with MockitoSugar with Wit
         override def twoStepVerificationEnabled = true
       }
 
-      when(ruleContext.currentCoAFEAuthority).thenReturn(Future.successful(CoAFEAuthority(None)))
+      when(ruleContext.currentCoAFEAuthority).thenReturn(Future.successful(CoAFEAuthority(None, "", "")))
       when(ruleContext.activeEnrolments).thenReturn(Future.successful(Set("some-enrolment")))
       when(ruleContext.enrolments).thenReturn(Future.successful(Seq.empty[GovernmentGatewayEnrolment]))
 


### PR DESCRIPTION
GET /profile endpoint is now deprecated. This call has been replaced with:

- call to auth - to get user enrolments
- call to user-details - to get affinity group

Urls are provided by the authority object.