### PR TITLE
TAR-72 Error handling when Auth service returns 401

### DIFF
--- a/app/auth/RouterAuthenticationProvider.scala
+++ b/app/auth/RouterAuthenticationProvider.scala
@@ -35,9 +35,12 @@ trait RouterAuthenticationProvider extends AuthenticationProvider {
   override def redirectToLogin(implicit request: Request[_]): Future[FailureResult] = Future.successful(Redirect(login))
 
   override def handleNotAuthenticated(implicit request: Request[_]): PartialFunction[UserCredentials, Future[Either[AuthContext, RouterAuthenticationProvider.FailureResult]]] = {
-    case UserCredentials(None, token@_) =>
-      Logger.info(s"No userId found - redirecting to login. user: None token : $token")
-      redirectToLogin.map(Right(_))
+   case UserCredentials(None, token@_) =>
+     Logger.info(s"No userId found - redirecting to login. user: None token: $token")
+     redirectToLogin.map(Right(_))
+   case UserCredentials(None, None) =>
+     Logger.info(s"No userId found - redirecting to login. user: None token: None")
+     redirectToLogin.map(Right(_))
   }
 }
 

--- a/it/router/RouterFeature.scala
+++ b/it/router/RouterFeature.scala
@@ -27,6 +27,23 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
 
   feature("Router feature") {
 
+    scenario("unauthorised response from auth should be handled with redirecting to login page") {
+
+      Given("a user logged in through Verify")
+      createStubs(TaxAccountUser(tokenPresent = false))
+
+      Given("auth returns Unauthorised")
+      stubAuthToReturn401()
+
+      createStubs(LoginPageStub)
+
+      When("the user hits the router")
+      go(RouterRootPath)
+
+      Then("the user should be routed to Login page")
+      on(LoginPage)
+    }
+
     scenario("a user logged in through Verify should be redirected to PTA") {
 
       Given("a user logged in through Verify")

--- a/it/support/page/LoginPage.scala
+++ b/it/support/page/LoginPage.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package support.page
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import support.Env
+import support.stubs.{Stub, StubbedPage}
+
+object LoginPageStub extends Stub with StubbedPage {
+  override def create() = {
+    stubOut(urlPathEqualTo("/account/sign-in?continue=/account"), "Login Page")
+  }
+}
+
+object LoginPage extends WebPage {
+  override val url: String = Env.host + "/account/sign-in?continue=/account"
+
+  override def assertPageLoaded() = assertPageIs("Login Page")
+}

--- a/it/support/stubs/CommonStubs.scala
+++ b/it/support/stubs/CommonStubs.scala
@@ -112,6 +112,11 @@ trait CommonStubs {
         .withStatus(404)))
   }
 
+  def stubAuthToReturn401() = stubFor(get(urlEqualTo("/auth/authority"))
+    .willReturn(
+      aResponse()
+        .withStatus(401)))
+
   def stubSaReturnToReturn500(saUtr: String) = {
     stubFor(get(urlMatching(s"/sa/individual/$saUtr/last-return"))
       .willReturn(aResponse()


### PR DESCRIPTION
Handle auth 401 with redirecting to the login page. Previously it was resolved to an Internal Server Error