### PR TITLE
TSV-316: Prevent One Time Login and Privileged Access users from failing.

### DIFF
--- a/app/model/RuleContext.scala
+++ b/app/model/RuleContext.scala
@@ -17,6 +17,7 @@
 package model
 
 import connector._
+import play.api.{Logger, LoggerLike}
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext.fromLoggingDetails
@@ -24,12 +25,17 @@ import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext.fromLoggingDetai
 import scala.concurrent.Future
 
 case class RuleContext(authContext: AuthContext)(implicit hc: HeaderCarrier) {
+  val logger: LoggerLike = Logger
   val selfAssessmentConnector: SelfAssessmentConnector = SelfAssessmentConnector
   val frontendAuthConnector: FrontendAuthConnector = FrontendAuthConnector
   val userDetailsConnector: UserDetailsConnector = UserDetailsConnector
 
   lazy val userDetails = currentCoAFEAuthority.flatMap { authority =>
-    userDetailsConnector.getUserDetails(authority.userDetailsLink)
+    authority.userDetailsLink.map(userDetailsConnector.getUserDetails).getOrElse {
+      val exception = new RuntimeException("userDetailsLink is not defined")
+      logger.warn("failed to get user details", exception)
+      Future.failed(exception)
+    }
   }
 
   lazy val activeEnrolmentKeys = activeEnrolments.map(enrList => enrList.map(_.key).toSet[String])
@@ -47,7 +53,7 @@ case class RuleContext(authContext: AuthContext)(implicit hc: HeaderCarrier) {
 
   lazy val currentCoAFEAuthority = frontendAuthConnector.currentCoAFEAuthority()
 
-  lazy val internalUserIdentifier = currentCoAFEAuthority.map(_.internalUserIdentifier)
+  lazy val internalUserIdentifier = currentCoAFEAuthority.map(authority => authority.internalUserIdentifier)
 
   lazy val enrolments = currentCoAFEAuthority.flatMap { authority =>
     lazy val noEnrolments = Future.successful(Seq.empty[GovernmentGatewayEnrolment])

--- a/app/services/ThrottlingService.scala
+++ b/app/services/ThrottlingService.scala
@@ -121,7 +121,10 @@ trait ThrottlingService extends BSONBuilderHelpers {
           }
       }
     }
-    ruleContext.internalUserIdentifier.flatMap(location)
+    ruleContext.internalUserIdentifier.flatMap {
+      case Some(identifier) => location(identifier)
+      case _ => Future.successful(initialLocation)
+    }
   }
 
   def doThrottling(location: Location, auditContext: TAuditContext, userIdentifier: InternalUserIdentifier)(implicit request: Request[AnyContent], ex: ExecutionContext): Future[Location] = {

--- a/app/services/TwoStepVerification.scala
+++ b/app/services/TwoStepVerification.scala
@@ -105,8 +105,8 @@ trait TwoStepVerification {
         throttleLocations <- throttleLocations(applicableRule)
         internalUserIdentifier <- ruleContext.internalUserIdentifier
       } yield {
-        (applicableRule, throttleLocations) match {
-          case (Some(rule), Some(locations)) => Some(throttleLocation(rule, locations, internalUserIdentifier))
+        (applicableRule, throttleLocations, internalUserIdentifier) match {
+          case (Some(rule), Some(locations), Some(identifier)) => Some(throttleLocation(rule, locations, identifier))
           case _ => None
         }
       }

--- a/it/router/RouterAuditTwoStepVerificationFeature.scala
+++ b/it/router/RouterAuditTwoStepVerificationFeature.scala
@@ -44,7 +44,7 @@ class RouterAuditTwoStepVerificationFeature extends StubbedFeatureSpec with Comm
     scenario("when there is an applicable rule and registration is optional for an admin") {
 
       Given("a user logged in through Government Gateway not registered for 2SV")
-      createStubs(TaxAccountUser(isRegisteredFor2SV = false, internalUserIdentifier = optionalUserId))
+      createStubs(TaxAccountUser(isRegisteredFor2SV = false, internalUserIdentifier = Some(optionalUserId)))
 
       And("user is admin")
       stubUserDetails(credentialRole = user)
@@ -76,7 +76,7 @@ class RouterAuditTwoStepVerificationFeature extends StubbedFeatureSpec with Comm
     scenario("when there is an applicable rule and registration is mandatory for an admin") {
 
       Given("a user logged in through Government Gateway not registered for 2SV")
-      createStubs(TaxAccountUser(isRegisteredFor2SV = false, internalUserIdentifier = mandatoryUserId))
+      createStubs(TaxAccountUser(isRegisteredFor2SV = false, internalUserIdentifier = Some(mandatoryUserId)))
 
       And("user is admin")
       stubUserDetails(credentialRole = user)

--- a/it/router/RouterFeature.scala
+++ b/it/router/RouterFeature.scala
@@ -392,6 +392,36 @@ class RouterFeature extends StubbedFeatureSpec with CommonStubs {
     }
   }
 
+  scenario("a user logged in through One Time Login or Privileged Access with no enrolments should go to BTA") {
+
+    Given("a user logged in through One Time Login or Privileged Access")
+    createStubs(TaxAccountUser(internalUserIdentifier = None, userDetailsLink = None))
+
+    And("the user has no inactive enrolments")
+    stubNoEnrolments()
+
+    createStubs(BtaHomeStubPage)
+
+    When("the user hits the router")
+    go(RouterRootPath)
+
+    Then("the user should be routed to BTA Home Page")
+    on(BtaHomePage)
+
+    And("the authority object should be fetched once for AuthenticatedBy, but ids are not fetched")
+    verify(getRequestedFor(urlEqualTo("/auth/authority")))
+    verify(0, getRequestedFor(urlEqualTo("/auth/ids-uri")))
+
+    And("user's enrolments should be fetched from Auth")
+    verify(getRequestedFor(urlEqualTo("/auth/enrolments-uri")))
+
+    And("user's details should not be fetched from User Details")
+    verify(0, getRequestedFor(urlEqualTo("/user-details-uri")))
+
+    And("Sa micro service should not be invoked")
+    verify(0, getRequestedFor(urlMatching("/sa/individual/.[^\\/]+/return/last")))
+  }
+
   private def verifyAuthorityObjectIsFetched = {
     verify(getRequestedFor(urlEqualTo("/auth/authority")))
     verify(getRequestedFor(urlEqualTo("/auth/ids-uri")))

--- a/it/support/stubs/TaxAccountUser.scala
+++ b/it/support/stubs/TaxAccountUser.scala
@@ -26,8 +26,8 @@ case class TaxAccountUser(loggedIn: Boolean = true,
                           accounts: Accounts = Accounts(),
                           credentialStrength: CredentialStrength = CredentialStrength.None,
                           affinityGroup: String = AffinityGroupValue.ORGANISATION,
-                          internalUserIdentifier : String = "id1234567890",
-                          userDetailsLink: String = s"http://${Env.stubHost}:${Env.stubPort}/user-details-uri")
+                          internalUserIdentifier : Option[String] = Some("id1234567890"),
+                          userDetailsLink: Option[String] = Some(s"http://${Env.stubHost}:${Env.stubPort}/user-details-uri"))
   extends Stub {
 
   def create() = {

--- a/test/engine/ConditionsSpec.scala
+++ b/test/engine/ConditionsSpec.scala
@@ -353,7 +353,7 @@ class ConditionsSpec extends UnitSpec with MockitoSugar with WithFakeApplication
 
         implicit val hc = HeaderCarrier.fromHeadersAndSession(fakeRequest.headers)
         val ruleContext = mock[RuleContext]
-        when(ruleContext.currentCoAFEAuthority).thenReturn(Future(CoAFEAuthority(twoFactorAuthOtpId, None, "", InternalUserIdentifier(""))))
+        when(ruleContext.currentCoAFEAuthority).thenReturn(Future(CoAFEAuthority(twoFactorAuthOtpId, None, Some(""), Some(InternalUserIdentifier("")))))
 
         val result = await(HasRegisteredFor2SV.isTrue(authContext, ruleContext))
 

--- a/test/model/RuleContextSpec.scala
+++ b/test/model/RuleContextSpec.scala
@@ -50,8 +50,9 @@ class RuleContextSpec extends UnitSpec with MockitoSugar with WithFakeApplicatio
 
     val enrolmentsUri = "/enrolments"
     val userDetailsLink = "/userDetailsLink"
+    val someIdsUri = "/ids-uri"
     val internalUserIdentifier = InternalUserIdentifier("user-id")
-    val expectedCoafeAuthority = CoAFEAuthority(None, enrolmentsUri = Some(enrolmentsUri), userDetailsLink = Some(userDetailsLink), internalUserIdentifier = Some(internalUserIdentifier))
+    val expectedCoafeAuthority = CoAFEAuthority(None, enrolmentsUri = Some(enrolmentsUri), userDetailsLink = Some(userDetailsLink), idsUri = Some(someIdsUri))
 
     val expectedAffinityGroup = "some-affinity-group"
     val expectedUserDetails = UserDetails(Some(CredentialRole("User")), expectedAffinityGroup)
@@ -64,6 +65,7 @@ class RuleContextSpec extends UnitSpec with MockitoSugar with WithFakeApplicatio
     when(mockUserDetailsConnector.getUserDetails(userDetailsLink)).thenReturn(Future.successful(expectedUserDetails))
     when(mockFrontendAuthConnector.getEnrolments(enrolmentsUri)).thenReturn(Future.successful(expectedActiveEnrolmentsSeq))
     when(mockFrontendAuthConnector.currentCoAFEAuthority()).thenReturn(Future.successful(expectedCoafeAuthority))
+    when(mockFrontendAuthConnector.getIds(someIdsUri)).thenReturn(Future.successful(internalUserIdentifier))
   }
 
   "activeEnrolments" should {
@@ -179,7 +181,7 @@ class RuleContextSpec extends UnitSpec with MockitoSugar with WithFakeApplicatio
       expectedException.getMessage shouldBe "userDetailsLink is not defined"
 
       verify(mockFrontendAuthConnector).currentCoAFEAuthority()
-      verify(mockLogger).warn("failed to get user details", expectedException)
+      verify(mockLogger).warn("failed to get user details because userDetailsLink is not defined")
       verifyNoMoreInteractions(allMocks: _*)
     }
   }

--- a/test/services/ThrottlingServiceSpec.scala
+++ b/test/services/ThrottlingServiceSpec.scala
@@ -88,7 +88,7 @@ class ThrottlingServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAft
         //and
         val mockRoutingCacheRepository = mock[RoutingCacheRepository]
         val mockRuleContext = mock[RuleContext]
-        when(mockRuleContext.internalUserIdentifier).thenReturn(Future.successful(userIdentifier))
+        when(mockRuleContext.internalUserIdentifier).thenReturn(Future.successful(Some(userIdentifier)))
 
         //when
         val returnedLocation: Future[Location] = new ThrottlingServiceTest(routingCacheRepository = mockRoutingCacheRepository).throttle(initialLocation, mockAuditContext, mockRuleContext)
@@ -124,7 +124,7 @@ class ThrottlingServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAft
           )(any[ExecutionContext])
         ).thenReturn(Future(initialLocation))
         val mockRuleContext = mock[RuleContext]
-        when(mockRuleContext.internalUserIdentifier).thenReturn(Future.successful(userIdentifier))
+        when(mockRuleContext.internalUserIdentifier).thenReturn(Future.successful(Some(userIdentifier)))
 
         //when
         val returnedLocation: Future[Location] = new ThrottlingServiceTest(routingCacheRepository = mockRoutingCacheRepository, hourlyLimitService = mockHourlyLimitService).throttle(initialLocation, mockAuditContext,mockRuleContext)
@@ -155,7 +155,7 @@ class ThrottlingServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAft
         //and
         val mockRoutingCacheRepository = mock[RoutingCacheRepository]
         val mockRuleContext = mock[RuleContext]
-        when(mockRuleContext.internalUserIdentifier).thenReturn(Future.successful(userIdentifier))
+        when(mockRuleContext.internalUserIdentifier).thenReturn(Future.successful(Some(userIdentifier)))
 
 
         //when
@@ -213,7 +213,7 @@ class ThrottlingServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAft
           //and
           val mockRoutingCacheRepository = mock[RoutingCacheRepository]
           val mockRuleContext = mock[RuleContext]
-          when(mockRuleContext.internalUserIdentifier).thenReturn(Future.successful(userIdentifier))
+          when(mockRuleContext.internalUserIdentifier).thenReturn(Future.successful(Some(userIdentifier)))
 
 
           //and
@@ -283,7 +283,7 @@ class ThrottlingServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAft
           when(mockRoutingCacheRepository.createOrUpdate(id, "routingInfo", Json.toJson(RoutingInfo(PersonalTaxAccount.name, expectedLocation, expectedExpirationTime)))).thenReturn(Future(mockDatabaseUpdateResult))
 
           val mockRuleContext = mock[RuleContext]
-          when(mockRuleContext.internalUserIdentifier).thenReturn(Future.successful(userIdentifier))
+          when(mockRuleContext.internalUserIdentifier).thenReturn(Future.successful(Some(userIdentifier)))
 
 
           //when
@@ -334,7 +334,7 @@ class ThrottlingServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAft
         when(mockRoutingCacheRepository.createOrUpdate(id, "routingInfo", Json.toJson(RoutingInfo(PersonalTaxAccount.name, BusinessTaxAccount.name, expectedExpirationTime)))).thenReturn(Future(mockDatabaseUpdateResult))
 
         val mockRuleContext = mock[RuleContext]
-        when(mockRuleContext.internalUserIdentifier).thenReturn(Future.successful(userIdentifier))
+        when(mockRuleContext.internalUserIdentifier).thenReturn(Future.successful(Some(userIdentifier)))
 
 
         //when
@@ -386,7 +386,7 @@ class ThrottlingServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAft
           val mockHourlyLimitService = Mocks.mockHourlyLimitService()
 
           val mockRuleContext = mock[RuleContext]
-          when(mockRuleContext.internalUserIdentifier).thenReturn(Future.successful(userIdentifier))
+          when(mockRuleContext.internalUserIdentifier).thenReturn(Future.successful(Some(userIdentifier)))
 
 
           //when
@@ -449,7 +449,7 @@ class ThrottlingServiceSpec extends UnitSpec with MockitoSugar with BeforeAndAft
             )(any[ExecutionContext])
           ).thenReturn(Future(routedLocation))
           val mockRuleContext = mock[RuleContext]
-          when(mockRuleContext.internalUserIdentifier).thenReturn(Future.successful(userIdentifier))
+          when(mockRuleContext.internalUserIdentifier).thenReturn(Future.successful(Some(userIdentifier)))
 
           //when
           val returnedLocation: Future[Location] = new ThrottlingServiceTest(routingCacheRepository = mockRoutingCacheRepository, hourlyLimitService = mockHourlyLimitService).throttle(routedLocation, mockAuditContext, mockRuleContext)

--- a/test/services/TwoStepVerificationServiceSpec.scala
+++ b/test/services/TwoStepVerificationServiceSpec.scala
@@ -60,7 +60,7 @@ class TwoStepVerificationServiceSpec extends UnitSpec with MockitoSugar with Wit
     val allMocks = Seq(auditContext, twoStepVerificationThrottleMock, ruleContext)
     val signOutUrl = "http://localhost:9025/sign-out"
     val internalUserIdentifier = InternalUserIdentifier("user-id")
-    val coAFEAuthorityWithOtpDisabled = CoAFEAuthority(None, None, "", InternalUserIdentifier(""))
+    val coAFEAuthorityWithOtpDisabled = CoAFEAuthority(None, None, Some(""), Some(InternalUserIdentifier("")))
 
     val twoStepVerification = new TwoStepVerification {
       override def twoStepVerificationPath = ???
@@ -113,7 +113,7 @@ class TwoStepVerificationServiceSpec extends UnitSpec with MockitoSugar with Wit
       when(ruleContext.currentCoAFEAuthority).thenReturn(Future.successful(coAFEAuthorityWithOtpDisabled))
       when(ruleContext.enrolments).thenReturn(Future.successful(Seq.empty[GovernmentGatewayEnrolment]))
       when(ruleContext.activeEnrolmentKeys).thenReturn(Future.successful(Set.empty[String]))
-      when(ruleContext.internalUserIdentifier).thenReturn(Future.successful(internalUserIdentifier))
+      when(ruleContext.internalUserIdentifier).thenReturn(Future.successful(Some(internalUserIdentifier)))
 
 
       val result = await(twoStepVerification.getDestinationVia2SV(BusinessTaxAccount, ruleContext, auditContext))
@@ -132,7 +132,7 @@ class TwoStepVerificationServiceSpec extends UnitSpec with MockitoSugar with Wit
       val loggedInUser = LoggedInUser("userId", None, None, None, CredentialStrength.Strong, ConfidenceLevel.L0)
       implicit val authContext = AuthContext(loggedInUser, principal, None)
       when(ruleContext.currentCoAFEAuthority).thenReturn(Future.successful(coAFEAuthorityWithOtpDisabled))
-      when(ruleContext.internalUserIdentifier).thenReturn(Future.successful(internalUserIdentifier))
+      when(ruleContext.internalUserIdentifier).thenReturn(Future.successful(Some(internalUserIdentifier)))
 
       val result = await(twoStepVerification.getDestinationVia2SV(BusinessTaxAccount, ruleContext, auditContext))
 
@@ -148,8 +148,8 @@ class TwoStepVerificationServiceSpec extends UnitSpec with MockitoSugar with Wit
       val loggedInUser = LoggedInUser("userId", None, None, None, CredentialStrength.None, ConfidenceLevel.L0)
       implicit val authContext = AuthContext(loggedInUser, principal, None)
 
-      when(ruleContext.currentCoAFEAuthority).thenReturn(Future.successful(CoAFEAuthority(Some("1234"), None, "", InternalUserIdentifier(""))))
-      when(ruleContext.internalUserIdentifier).thenReturn(Future.successful(internalUserIdentifier))
+      when(ruleContext.currentCoAFEAuthority).thenReturn(Future.successful(CoAFEAuthority(Some("1234"), None, Some(""), Some(InternalUserIdentifier("")))))
+      when(ruleContext.internalUserIdentifier).thenReturn(Future.successful(Some(internalUserIdentifier)))
 
       val result = await(twoStepVerification.getDestinationVia2SV(BusinessTaxAccount, ruleContext, auditContext))
 
@@ -167,7 +167,7 @@ class TwoStepVerificationServiceSpec extends UnitSpec with MockitoSugar with Wit
 
       when(ruleContext.currentCoAFEAuthority).thenReturn(Future.successful(coAFEAuthorityWithOtpDisabled))
       when(ruleContext.enrolments).thenReturn(Future.failed(new InternalServerException("GG returns 500")))
-      when(ruleContext.internalUserIdentifier).thenReturn(Future.successful(internalUserIdentifier))
+      when(ruleContext.internalUserIdentifier).thenReturn(Future.successful(Some(internalUserIdentifier)))
 
 
       val result = await(twoStepVerification.getDestinationVia2SV(BusinessTaxAccount, ruleContext, auditContext))
@@ -188,7 +188,7 @@ class TwoStepVerificationServiceSpec extends UnitSpec with MockitoSugar with Wit
       when(ruleContext.currentCoAFEAuthority).thenReturn(Future.successful(coAFEAuthorityWithOtpDisabled))
       when(ruleContext.enrolments).thenReturn(Future.successful(Seq.empty[GovernmentGatewayEnrolment]))
       when(ruleContext.activeEnrolmentKeys).thenReturn(Future.successful(Set("IR-SA", "some-other-enrolment")))
-      when(ruleContext.internalUserIdentifier).thenReturn(Future.successful(internalUserIdentifier))
+      when(ruleContext.internalUserIdentifier).thenReturn(Future.successful(Some(internalUserIdentifier)))
 
       val result = await(twoStepVerification.getDestinationVia2SV(BusinessTaxAccount, ruleContext, auditContext))
 
@@ -233,7 +233,7 @@ class TwoStepVerificationServiceSpec extends UnitSpec with MockitoSugar with Wit
         val loggedInUser = LoggedInUser("", None, None, None, CredentialStrength.Weak, ConfidenceLevel.L0)
         implicit val authContext = AuthContext(loggedInUser, principal, None)
 
-        when(ruleContext.currentCoAFEAuthority).thenReturn(Future.successful(CoAFEAuthority(None, None, "", internalUserIdentifier)))
+        when(ruleContext.currentCoAFEAuthority).thenReturn(Future.successful(CoAFEAuthority(None, None, Some(""), Some(internalUserIdentifier))))
         when(ruleContext.activeEnrolmentKeys).thenReturn(Future.successful(enrolments))
         when(ruleContext.isAdmin).thenReturn(Future.successful(isAdmin))
         val activeGGEnrolments = enrolments.map(GovernmentGatewayEnrolment(_, Seq(), "Activated")).toSeq
@@ -243,7 +243,7 @@ class TwoStepVerificationServiceSpec extends UnitSpec with MockitoSugar with Wit
         when(ruleContext.userDetails).thenReturn(Future.successful(UserDetails(Some(CredentialRole(credentialRole)), "affinityGroup")))
 
         when(ruleContext.enrolments).thenReturn(Future.successful(Seq.empty[GovernmentGatewayEnrolment]))
-        when(ruleContext.internalUserIdentifier).thenReturn(Future.successful(internalUserIdentifier))
+        when(ruleContext.internalUserIdentifier).thenReturn(Future.successful(Some(internalUserIdentifier)))
         when(twoStepVerificationThrottleMock.isRegistrationMandatory(expectedRuleName, internalUserIdentifier)).thenReturn(Future.successful(isMandatory))
         when(auditConnectorMock.sendEvent(any[AuditEvent])(any[HeaderCarrier], any[ExecutionContext])).thenReturn(Future.successful(mock[AuditResult]))
 


### PR DESCRIPTION
One Time Login and Privileged Access users have transient sessions. The authority object in this case has no `ids` and no `userDetailsLink` fields.